### PR TITLE
Fixes enabling zap extender scripts on 2.14.0

### DIFF
--- a/zap-extender/copy-curl-loop.js
+++ b/zap-extender/copy-curl-loop.js
@@ -7,7 +7,7 @@
 var requests = 25;
 
 // Script variable to use when uninstalling
-var popupmenuitemtype = Java.type("org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer");
+var popupmenuitemtype = Java.extend(Java.type("org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer"));
 var curlmenuitem = new popupmenuitemtype("Copy curl command to test for Race Condition") {
 	performAction: function(href) {
 		invokeWith(href.getHttpMessage());

--- a/zap-extender/forward-to-race-dispatcher.js
+++ b/zap-extender/forward-to-race-dispatcher.js
@@ -7,7 +7,7 @@ var proxyOn = false;
 var proxy = "localhost:8080";
 
 // Script variable to use when unregistering
-var popupmenuitemtype = Java.type("org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer");
+var popupmenuitemtype = Java.extend(Java.type("org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer"));
 var curlmenuitem = new popupmenuitemtype("Forward Request to Race Dispatcher") {
 	performAction: function(href) {
 		invokeWith(href.getHttpMessage());


### PR DESCRIPTION
It appears that the extender scripts were not working. It looks like ZAP might have had an update since they were last touched that broke them. This matches the current templates and fixes the problem.